### PR TITLE
Analyze packages with `--fatal-infos` by default

### DIFF
--- a/workflow-templates/test-package.yaml
+++ b/workflow-templates/test-package.yaml
@@ -33,7 +33,7 @@ jobs:
         run: dart format --output=none --set-exit-if-changed .
         if: always() && steps.install.outcome == 'success'
       - name: Analyze code
-        run: dart analyze
+        run: dart analyze --fatal-infos
         if: always() && steps.install.outcome == 'success'
 
   # Run tests on a matrix consisting of two dimensions:


### PR DESCRIPTION
Many packages did this on Travis, so we want to do this by default to keep the old behavior. Note that dart analyze does `--fatal-warnings` by default so we don't need to add that here.