### PR TITLE
add a CONTRIBUTING.md doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,20 @@ use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
 
+## Coding style
+
+The Dart source code in this repo follows the:
+
+  * [Dart style guide](https://dart.dev/guides/language/effective-dart/style)
+
+You should familiarize yourself with those guidelines.
+
 ## File headers
 
-All files in the project must start with the following header:
+All files in the Dart project must start with the following header. If you add a
+new file please also add this. The year should be a single number (not a range;
+don't use "2011-2012", even if the original code did). If you edit an existing
+file you don't have to update the year.
 
     // Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
     // for details. All rights reserved. Use of this source code is governed by a
@@ -35,3 +46,6 @@ All files in the project must start with the following header:
 
 This project follows
 [Google's Open Source Community Guidelines](https://opensource.google/conduct/).
+
+We pledge to maintain an open and welcoming environment. For details, see our
+[code of conduct](https://dart.dev/code-of-conduct).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,27 @@
-Want to contribute? Great! First, read this page (including the small print at
-the end).
+# How to Contribute
 
-### Before you contribute
-Before we can use your code, you must sign the
-[Google Individual Contributor License Agreement](https://cla.developers.google.com/about/google-individual)
-(CLA), which you can do online. The CLA is necessary mainly because you own the
-copyright to your changes, even after your contribution becomes part of our
-codebase, so we need your permission to use and distribute your code. We also
-need to be sure of various other things—for instance that you'll tell us if you
-know that your code infringes on other people's patents. You don't have to sign
-the CLA until after you've submitted your code for review and a member has
-approved it, but you must do it before we can put your code into our codebase.
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
 
-Before you start working on a larger contribution, you should get in touch with
-us first through the issue tracker with your idea so that we can help out and
-possibly guide you. Coordinating up front makes it much easier to avoid
-frustration later on.
+## Contributor License Agreement
 
-### Code reviews
-All submissions, including submissions by project members, require review.
+Contributions to this project must be accompanied by a Contributor License
+Agreement (CLA). You (or your employer) retain the copyright to your
+contribution; this simply gives us permission to use and redistribute your
+contributions as part of the project. Head over to
+<https://cla.developers.google.com/> to see your current agreements on file or
+to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Code Reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
 
 ### File headers
 All files in the project must start with the following header.
@@ -27,7 +30,7 @@ All files in the project must start with the following header.
     // for details. All rights reserved. Use of this source code is governed by a
     // BSD-style license that can be found in the LICENSE file.
 
-### The small print
-Contributions made by corporations are covered by a different agreement than the
-one above, the
-[Software Grant and Corporate Contributor License Agreement](https://developers.google.com/open-source/cla/corporate).
+## Community Guidelines
+
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google/conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+Want to contribute? Great! First, read this page (including the small print at
+the end).
+
+### Before you contribute
+Before we can use your code, you must sign the
+[Google Individual Contributor License Agreement](https://cla.developers.google.com/about/google-individual)
+(CLA), which you can do online. The CLA is necessary mainly because you own the
+copyright to your changes, even after your contribution becomes part of our
+codebase, so we need your permission to use and distribute your code. We also
+need to be sure of various other things—for instance that you'll tell us if you
+know that your code infringes on other people's patents. You don't have to sign
+the CLA until after you've submitted your code for review and a member has
+approved it, but you must do it before we can put your code into our codebase.
+
+Before you start working on a larger contribution, you should get in touch with
+us first through the issue tracker with your idea so that we can help out and
+possibly guide you. Coordinating up front makes it much easier to avoid
+frustration later on.
+
+### Code reviews
+All submissions, including submissions by project members, require review.
+
+### File headers
+All files in the project must start with the following header.
+
+    // Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+    // for details. All rights reserved. Use of this source code is governed by a
+    // BSD-style license that can be found in the LICENSE file.
+
+### The small print
+Contributions made by corporations are covered by a different agreement than the
+one above, the
+[Software Grant and Corporate Contributor License Agreement](https://developers.google.com/open-source/cla/corporate).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
 
-### File headers
+## File headers
 All files in the project must start with the following header.
 
     // Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,8 @@ use GitHub pull requests for this purpose. Consult
 information on using pull requests.
 
 ## File headers
-All files in the project must start with the following header.
+
+All files in the project must start with the following header:
 
     // Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
     // for details. All rights reserved. Use of this source code is governed by a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,10 @@ You should familiarize yourself with those guidelines.
 
 ## File headers
 
-All files in the Dart project must start with the following header. If you add a
-new file please also add this. The year should be a single number (not a range;
-don't use "2011-2012", even if the original code did). If you edit an existing
-file you don't have to update the year.
+All files in the Dart project must start with the following header; if you add a
+new file please also add this. The year should be a single number stating the
+year the file was created (don't use a range like "2011-2012"). Additionally, if
+you edit an existing file, you shouldn't update the year.
 
     // Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
     // for details. All rights reserved. Use of this source code is governed by a


### PR DESCRIPTION
- add a default `CONTRIBUTING.md` doc for dart-lang/ repos
- fix https://github.com/dart-lang/.github/issues/25

This file was cargo-culted from dart-lang/build and update slightly (it looked similar to many of our other contributing files however).