### PR TITLE
Adding the org level configuration file for autosubmit.

### DIFF
--- a/autosubmit/autosubmit.yml
+++ b/autosubmit/autosubmit.yml
@@ -1,0 +1,17 @@
+# Copyright 2023 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+allow_config_override: false
+auto_approval_accounts:
+  - dependabot[bot]
+  - dependabot
+approving_reviews: 2
+approval_group: dart-team
+run_ci: true
+support_no_review_revert: true
+required_checkruns:
+  - "cla/google"
+  - "analyze (dev)"
+  - "test (ubuntu-latest, 2.18.0)"
+  - "test (ubuntu-latest, dev)"


### PR DESCRIPTION
This is the top level configuration file for Flutter's autosubmit bot. It will allow autosubmit to support the dart-lang libraries with minimal configuration.

I currently have configuration override set to false for dart-lang as we are testing only on a single repository (pubspec_parse) and testing for configuration override is still ongoing.

Autosubmit has already been installed into dart-lang.

As I have been working only with Devon, here is the in progress design document for this effort: https://docs.google.com/document/d/14pf4jfBy1-PHYmJLVbeqrh1swTF01SZ2YD3DR_Qv3kM/edit?usp=sharing&resourcekey=0-AW7-kNNGmmpSUqyOvBdwRg